### PR TITLE
Fix color-input-controller

### DIFF
--- a/wagtail_color_panel/static/wagtail_color_panel/js/color-input-controller.js
+++ b/wagtail_color_panel/static/wagtail_color_panel/js/color-input-controller.js
@@ -6,4 +6,4 @@ class ColorInputController extends window.StimulusModule.Controller {
     }
 }
 
-window.wagtail.app.register('read-only-uuid', ColorInputController);
+window.wagtail.app.register('color-input', ColorInputController);


### PR DESCRIPTION
`read-only-uuid` should match `color-input` as set in the `data-controller` attribute