### PR TITLE
Drop Wagtail 6.3/7.2 (EOL), add Wagtail 7.4 LTS support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,26 +15,25 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        wagtail-version: ["6.3", "7.0", "7.2", "7.3"]
+        wagtail-version: ["7.0", "7.3", "7.4"]
         django-version: ["4.2", "5.2", "6.0"]
         exclude:
-          # Don't test django with incompatible python versions
+          # Django 4.2 only supports Python up to 3.12
           - python-version: "3.13"
             django-version: "4.2"
           - python-version: "3.14"
             django-version: "4.2"
+          # Don't test django with incompatible python versions
           - python-version: "3.10"
             django-version: "6.0"
           - python-version: "3.11"
             django-version: "6.0"
           # Don't test wagtail with incompatible django versions
-          - wagtail-version: "6.3"
-            django-version: "6.0"
           - wagtail-version: "7.0"
             django-version: "6.0"
+          - wagtail-version: "7.4"
+            django-version: "4.2"
           # Don't test wagtail with incompatible python versions
-          - wagtail-version: "6.3"
-            python-version: "3.14"
           - wagtail-version: "7.0"
             python-version: "3.14"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add Wagtail 7.4 LTS support
 ### Changed
 ### Fixed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 ### Removed
+- Drop support for EOL Wagtail 6.3 LTS
+- Drop support for EOL Wagtail 7.2
 
 ## [1.8.1] - 2026-04-12
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Introduces panels for selecting colors in Wagtail.
 - NativeColorBlock for usage in a StreamField
 - Based on the native HTML5 color picker
 - A custom db field for improved validation
-- PolyfillColorPanel for cases that require IE11 support (built on [Spectrum](https://github.com/bgrins/spectrum))
+- PolyfillColorPanel (deprecated, will be removed in 2.0.0 — use NativeColorPanel instead)
 
 
 ## Example

--- a/docs/1_getting_started.md
+++ b/docs/1_getting_started.md
@@ -3,7 +3,7 @@
 ### Requirements
 
 - Python 3.10+
-- Wagtail 6.3+ and Django 4.2+
+- Wagtail 7.0+ and Django 4.2+
 - [A browser that supports `input type="color"`](https://caniuse.com/#feat=input-color)
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-install_requires = ["wagtail>=6.3"]
+install_requires = ["wagtail>=7.0"]
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
@@ -45,7 +45,6 @@ setup(
         "Framework :: Django :: 5.2",
         "Framework :: Django :: 6.0",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 6",
         "Framework :: Wagtail :: 7",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase
-from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.test.utils import WagtailTestUtils
 
 from wagtail_color_panel.blocks import NativeColorBlock
@@ -17,10 +16,7 @@ class BlockTest(TestCase, WagtailTestUtils):
     def test_form_uses_proper_input_type(self):
         block = NativeColorBlock()
 
-        if WAGTAIL_VERSION >= (6, 0):
-            html = block.field.widget.render(name="cat", value="#333333", attrs={})
-        else:
-            html = block.field.widget.render_html(name="cat", value="#333333", attrs={})
+        html = block.field.widget.render(name="cat", value="#333333", attrs={})
 
         self.assertEqual(block.field.widget.__class__, ColorInputWidget)
         self.assertIn('type="color"', html)


### PR DESCRIPTION
## Summary

Maintenance update aligning the Wagtail support range with the current release schedule.

- Raise minimum to `wagtail>=7.0`; drop EOL Wagtail 6.3 LTS and 7.2 from `install_requires`, classifiers, and CI
- Add Wagtail 7.4 LTS (released 2026-05-04) to the CI matrix
- Keep Django 4.2 LTS — still supported by Wagtail 7.0 LTS and 7.3
- Exclude the Wagtail 7.4 + Django 4.2 combination (7.4 dropped Django 4.2)
- Remove stale `WAGTAIL_VERSION >= (6, 0)` test guard now that the minimum is 7.0
- Update `README.md` and `docs/1_getting_started.md` to state the new Wagtail 7.0+ minimum
- Refresh the PolyfillColorPanel feature blurb to note its deprecation
- Record the additions and EOL drops in `CHANGELOG.md` under `[Unreleased]`

Resulting supported matrix: Python 3.10–3.14, Django 4.2/5.2/6.0, Wagtail 7.0/7.3/7.4 (with Wagtail 7.1/7.2 excluded as EOL).

The `wagtail.admin.telepath` vs `wagtail.telepath` guard in `widgets.py` is intentionally retained because Wagtail 7.0 LTS remains in the supported range.

## Test plan

- [ ] CI matrix passes across all Python × Django × Wagtail combinations
- [ ] Local `python runtests.py` passes against Wagtail 7.4 + Django 6.0 + Python 3.13
- [ ] Local `python runtests.py` passes against Wagtail 7.0 + Django 4.2 + Python 3.10
- [ ] `black --check` and `isort --check-only` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)